### PR TITLE
m1 support build libclash

### DIFF
--- a/build-clash-lib.py
+++ b/build-clash-lib.py
@@ -1,15 +1,22 @@
 #!/usr/bin/python3
 import os
 import sys
+import platform
 
 if __name__ == "__main__":
     os.chdir("clash")
     os.environ["CGO_ENABLED"] = "1"
-    file_name = "libclash.so"
+    output = "libclash"
     if sys.platform == 'win32':
-        file_name = "libclash.dll"
+        output += ".dll"
     elif sys.platform == "darwin":
-        file_name = "libclash.dylib"
-    os.system(f"go build -buildmode=c-shared -o {file_name}")
+        output += ".dylib"
+    else:
+        output += ".so"
+    processor = platform.processor()
+    if "arm" in processor or "Apple" in processor:
+        print("[warn] arm/Apple also compiles out amd64 target")
+        os.environ["GOARCH"] = "amd64"
+    os.system(f"go build -buildmode=c-shared -o {output}")
 
     os.chdir("..")


### PR DESCRIPTION
build-clash-lib.py 脚本中, 遇到m1机器手动设置 GOARCH=amd64